### PR TITLE
Fix build dependencies

### DIFF
--- a/pigeon-hole.egg
+++ b/pigeon-hole.egg
@@ -10,7 +10,8 @@
   (extension
    pigeonry
    (types-file)
-   (csc-options -O3 -lfa2 -d2 -no-trace -no-lambda-info))
+   (csc-options -O3 -lfa2 -d2 -no-trace -no-lambda-info)
+   (component-dependencies pigeon-hole))
   (extension
    pigeon-hole
    (types-file)


### PR DESCRIPTION
The `pigeonry` module depends on `pigeon-hole`, so the latter must be
built before the former.  This is achieved by specifying `pigeon-hole`
as a component dependency of `pigeonry`.

This issue has been exposed by b175ce65fe17c in the chicken-core
repository.